### PR TITLE
Remove stray ^B character

### DIFF
--- a/docs/atom.xml
+++ b/docs/atom.xml
@@ -435,7 +435,7 @@ sel (a :&gt; (x, b :&gt; x&#39;))
 <span id="cb1-5"><a href="#cb1-5" aria-hidden="true"></a><span class="va">+   deriving newtype (Eq, Ord, Show, Read, FromJSON)</span></span>
 <span id="cb1-6"><a href="#cb1-6" aria-hidden="true"></a><span class="va">+</span></span>
 <span id="cb1-7"><a href="#cb1-7" aria-hidden="true"></a><span class="va">+ type BufferOffset = Offset &#39;File</span></span>
-<span id="cb1-8"><a href="#cb1-8" aria-hidden="true"></a><span class="va">+ type LineOffset = Offset &#39;Line</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true"></a><span class="va">+ type LineOffset = Offset &#39;Line</span></span>
 <span id="cb1-9"><a href="#cb1-9" aria-hidden="true"></a></span>
 <span id="cb1-10"><a href="#cb1-10" aria-hidden="true"></a>  data Position&#39; a = Pn</span>
 <span id="cb1-11"><a href="#cb1-11" aria-hidden="true"></a>    { srcFile :: !a</span>

--- a/docs/blog/underline-bugs/index.html
+++ b/docs/blog/underline-bugs/index.html
@@ -78,7 +78,7 @@
 <span id="cb1-5"><a href="#cb1-5" aria-hidden="true"></a><span class="va">+   deriving newtype (Eq, Ord, Show, Read, FromJSON)</span></span>
 <span id="cb1-6"><a href="#cb1-6" aria-hidden="true"></a><span class="va">+</span></span>
 <span id="cb1-7"><a href="#cb1-7" aria-hidden="true"></a><span class="va">+ type BufferOffset = Offset &#39;File</span></span>
-<span id="cb1-8"><a href="#cb1-8" aria-hidden="true"></a><span class="va">+ type LineOffset = Offset &#39;Line</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true"></a><span class="va">+ type LineOffset = Offset &#39;Line</span></span>
 <span id="cb1-9"><a href="#cb1-9" aria-hidden="true"></a></span>
 <span id="cb1-10"><a href="#cb1-10" aria-hidden="true"></a>  data Position&#39; a = Pn</span>
 <span id="cb1-11"><a href="#cb1-11" aria-hidden="true"></a>    { srcFile :: !a</span>

--- a/docs/feed.rss
+++ b/docs/feed.rss
@@ -435,7 +435,7 @@ sel (a :&gt; (x, b :&gt; x&#39;))
 <span id="cb1-5"><a href="#cb1-5" aria-hidden="true"></a><span class="va">+   deriving newtype (Eq, Ord, Show, Read, FromJSON)</span></span>
 <span id="cb1-6"><a href="#cb1-6" aria-hidden="true"></a><span class="va">+</span></span>
 <span id="cb1-7"><a href="#cb1-7" aria-hidden="true"></a><span class="va">+ type BufferOffset = Offset &#39;File</span></span>
-<span id="cb1-8"><a href="#cb1-8" aria-hidden="true"></a><span class="va">+ type LineOffset = Offset &#39;Line</span></span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true"></a><span class="va">+ type LineOffset = Offset &#39;Line</span></span>
 <span id="cb1-9"><a href="#cb1-9" aria-hidden="true"></a></span>
 <span id="cb1-10"><a href="#cb1-10" aria-hidden="true"></a>  data Position&#39; a = Pn</span>
 <span id="cb1-11"><a href="#cb1-11" aria-hidden="true"></a>    { srcFile :: !a</span>

--- a/site/posts/2022-01-31-underline-bugs.markdown
+++ b/site/posts/2022-01-31-underline-bugs.markdown
@@ -84,7 +84,7 @@ controlled all of the Agda-serialization stuff, so I [made a patch][diff]:
 +   deriving newtype (Eq, Ord, Show, Read, FromJSON)
 +
 + type BufferOffset = Offset 'File
-+ type LineOffset = Offset 'Line
++ type LineOffset = Offset 'Line
 
   data Position' a = Pn
     { srcFile :: !a


### PR DESCRIPTION
A ^B (U+0002 START OF TEXT) character snuck into one of your blog posts. This results in [invalid](https://reasonablypolymorphic.com/atom.xml) RSS and Atom feeds which confuses Thunderbird.